### PR TITLE
events translate + refresh num interested fix

### DIFF
--- a/src/components/reservant/profile/events/EventList.tsx
+++ b/src/components/reservant/profile/events/EventList.tsx
@@ -21,7 +21,7 @@ const EventList: React.FC<EventListProps> = ({ listType }) => {
   const location = useLocation()
 
   const apiRoutes: Record<EventListType, string> = {
-    [EventListType.Created]: '/user/events?category=CreatedBy',
+    [EventListType.Created]: '/user/events?category=CreatedBy&order=DateDesc',
     [EventListType.Interested]: '/user/events?category=InterestedIn',
     [EventListType.Participates]: '/user/events?category=ParticipateIn',
     [EventListType.History]: '/events?friendsOnly=false'

--- a/src/components/reservant/profile/events/ParticipantMenageDialog.tsx
+++ b/src/components/reservant/profile/events/ParticipantMenageDialog.tsx
@@ -108,10 +108,10 @@ const ParticipantMenageDialog: React.FC<ParticipantMenageDialogProps> = ({
                       <Tooltip
                         title={
                           isPastDeadline
-                            ? t('ParticipantMenageDialog.pastAcceptTime')
+                            ? t('ParticipantManageDialog.pastAcceptTime')
                             : isLimitReached
-                              ? t('ParticipantMenageDialog.participantLimit')
-                              : t('ParticipantMenageDialog.acceptParticipant')
+                              ? t('ParticipantManageDialog.participantLimit')
+                              : t('ParticipantManageDialog.acceptParticipant')
                         }
                       >
                         <button
@@ -131,7 +131,7 @@ const ParticipantMenageDialog: React.FC<ParticipantMenageDialogProps> = ({
                         </button>
                       </Tooltip>
                       {/* Reject button */}
-                      <Tooltip title={t('ParticipantMenageDialog.decline')}>
+                      <Tooltip title={t('ParticipantManageDialog.decline')}>
                         <button
                           className="text-danger"
                           onClick={() => onRejectUser(user.userId)}

--- a/src/components/reservant/restaurant/onMapView/FocusedRestaurantEventDetails.tsx
+++ b/src/components/reservant/restaurant/onMapView/FocusedRestaurantEventDetails.tsx
@@ -148,7 +148,7 @@ const FocusedRestaurantEventDetails: React.FC<
               <span className="font-mont-bd text-primary dark:text-secondary">
                 {t('profile.events.participants')}:
               </span>{' '}
-              {event.numberInterested}
+              {interested}
             </p>
             <p>
               <span className="font-mont-bd text-primary dark:text-secondary">
@@ -189,10 +189,10 @@ const FocusedRestaurantEventDetails: React.FC<
               disabled
               className="w-3/4 px-4 py-2 rounded-lg bg-grey-3 text-black cursor-not-allowed"
             >
-              Jesteś twórcą tego eventu
+              {t('profile.events.created')}
             </button>
           )}
-          <Tooltip title="See participants" arrow>
+          <Tooltip title={t('profile.events.see-participants')} arrow>
             <button
               onClick={() => setShowParticipantsDialog(true)}
               className="px-4 py-2 text-primary dark:border-secondary dark:text-secondary hover:bg-primary hover:text-white border-primary dark:hover:bg-secondary dark:hover:text-black border-[1px] rounded-md flex items-center"
@@ -239,11 +239,11 @@ const FocusedRestaurantEventDetails: React.FC<
         <Dialog
           open={showLeaveDialog}
           onClose={() => setShowLeaveDialog(false)}
-          title="Potwierdzenie wyjścia"
+          title={t('profile.events.confirm-exit-title')}
         >
           <div className="p-4 dark:text-white">
             <p className="mb-4">
-              Czy na pewno chcesz opuścić wydarzenie{' '}
+            {t('profile.events.confirm-exit')}{' '}
               <strong>{event.name}</strong>?
             </p>
             <div className="flex justify-end gap-2">
@@ -251,13 +251,13 @@ const FocusedRestaurantEventDetails: React.FC<
                 className="px-4 py-2 transition text-primary dark:border-secondary dark:text-secondary hover:bg-primary hover:text-white border-primary dark:hover:bg-secondary dark:hover:text-black border-[1px] rounded-md"
                 onClick={handleLeaveEvent}
               >
-                Tak
+                {t('customer-service.visit-details.yes')}
               </button>
               <button
                 className="px-4 py-2 transition text-primary dark:border-secondary dark:text-secondary hover:bg-primary hover:text-white border-primary dark:hover:bg-secondary dark:hover:text-black border-[1px] rounded-md"
                 onClick={() => setShowLeaveDialog(false)}
               >
-                Nie
+                {t('customer-service.visit-details.no')}
               </button>
             </div>
           </div>

--- a/src/translations/en/global.json
+++ b/src/translations/en/global.json
@@ -787,7 +787,9 @@
             "no-event-history": "No events to view.",
             "friend-participate": "One or more of your friends participated in this event.",
             "you-created-event": "You created an event.",
-            "see-participants": "see participants"
+            "see-participants": "See participants",
+            "confirm-exit": "Are you sure you want to leave",
+            "confirm-exit-title": "Confirm exit"
         },
         "reports" : {
             "reports": "Reports",

--- a/src/translations/pl/global.json
+++ b/src/translations/pl/global.json
@@ -784,7 +784,9 @@
             "no-event-history": "Brak wydarzeń do wyświetlenia.",
             "friend-participate": "Jeden albo więcej Twoich znajomych uczestniczył w tym wydarzeniu.",
             "you-created-event": "Utworzyłeś wydarzenie.",
-            "see-participants": "Zobacz uczestników"
+            "see-participants": "Zobacz uczestników",
+            "confirm-exit": "Czy na pewno chcesz opuścić wydarzenie",
+            "confirm-exit-title": "Potwierdzenie wyjścia"
         },
         "reports" : {
             "reports": "Zgłoszenia",


### PR DESCRIPTION
- poprawienie tłumaczeń zarządzania członkami eventów
- odświeżanie liczby interested od razu po kliknięciu przycisku zainteresowania
- tłumaczenia dialogu opuszczania eventu
- poprawiona kolejność wyświetlania eventów created by w profilu